### PR TITLE
fix: session timeouts

### DIFF
--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -1,15 +1,15 @@
 import SwiftUI
+
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #endif
 
-
 @available(macOS 10.15, *)
-public class AccrueContextData: ObservableObject {
-    @Published public var  userData: AccrueUserData
-    @Published public var  settingsData: AccrueSettingsData
-    @Published public var  actions: AccrueActionsData
-    
+public class AccrueContextData: ObservableObject, Equatable {
+    @Published public var userData: AccrueUserData
+    @Published public var settingsData: AccrueSettingsData
+    @Published public var actions: AccrueActionsData
+
     public init(
         userData: AccrueUserData = AccrueUserData(),
         settingsData: AccrueSettingsData = AccrueSettingsData(),
@@ -19,8 +19,19 @@ public class AccrueContextData: ObservableObject {
         self.settingsData = settingsData
         self.actions = actions
     }
-    public func updateUserData(referenceId: String?, email: String?, phoneNumber: String?, additionalData: [String: String]?) {
-        userData = AccrueUserData(referenceId: referenceId, email: email, phoneNumber: phoneNumber, additionalData: additionalData)
+
+    public static func == (lhs: AccrueContextData, rhs: AccrueContextData) -> Bool {
+        return lhs.userData == rhs.userData && lhs.settingsData == rhs.settingsData
+            && lhs.actions == rhs.actions
+    }
+
+    public func updateUserData(
+        referenceId: String?, email: String?, phoneNumber: String?,
+        additionalData: [String: String]?
+    ) {
+        userData = AccrueUserData(
+            referenceId: referenceId, email: email, phoneNumber: phoneNumber,
+            additionalData: additionalData)
     }
     public func updateSettingsData(shouldInheritAuthentication: Bool) {
         settingsData = AccrueSettingsData(shouldInheritAuthentication: shouldInheritAuthentication)
@@ -28,17 +39,17 @@ public class AccrueContextData: ObservableObject {
     public func setAction(action: String) {
         actions = AccrueActionsData(action: action)
     }
-    public func clearAction(){
+    public func clearAction() {
         actions = AccrueActionsData()
     }
-    
+
 }
-public struct AccrueUserData {
+public struct AccrueUserData: Equatable {
     public let referenceId: String?
     public let email: String?
     public let phoneNumber: String?
     public let additionalData: [String: String]?
-    
+
     public init(
         referenceId: String? = nil,
         email: String? = nil,
@@ -52,18 +63,18 @@ public struct AccrueUserData {
     }
 }
 
-public struct AccrueActionsData {
+public struct AccrueActionsData: Equatable {
     public let action: String?
-    
-    public init( action: String? = nil) {
+
+    public init(action: String? = nil) {
         self.action = action
     }
 }
 
-public struct AccrueSettingsData {
+public struct AccrueSettingsData: Equatable {
     public let shouldInheritAuthentication: Bool
-    
-    public init( shouldInheritAuthentication: Bool = true) {
+
+    public init(shouldInheritAuthentication: Bool = true) {
         self.shouldInheritAuthentication = shouldInheritAuthentication
     }
 }
@@ -84,37 +95,42 @@ public struct AccrueDeviceContextData {
     public let osVersion: String?
     // iOS only
     public let modelId: String?
-    
-    public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
-#if canImport(UIKit)
-        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-        self.brand = brand ?? "Apple"
-        self.deviceName = deviceName ?? UIDevice.current.name
-        self.deviceType = deviceType ?? UIDevice.current.model
-        self.deviceYearClass = deviceYearClass
-        self.isDevice = isDevice ?? true
-        self.manufacturer = manufacturer ?? "Apple"
-        self.modelName = modelName ?? UIDevice.current.model
-        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osName = osName ?? UIDevice.current.systemName
-        self.osVersion = osVersion ?? UIDevice.current.systemVersion
-        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-#else
-        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-        self.brand = brand ?? "Apple"
-        self.deviceName = deviceName
-        self.deviceType = deviceType
-        self.deviceYearClass = deviceYearClass
-        self.isDevice = isDevice ?? true
-        self.manufacturer = manufacturer ?? "Apple"
-        self.modelName = modelName
-        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-        self.osName = osName
-        self.osVersion = osVersion
-        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-#endif
+
+    public init(
+        sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil,
+        deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true,
+        manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil,
+        osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil,
+        modelId: String? = nil
+    ) {
+        #if canImport(UIKit)
+            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+            self.brand = brand ?? "Apple"
+            self.deviceName = deviceName ?? UIDevice.current.name
+            self.deviceType = deviceType ?? UIDevice.current.model
+            self.deviceYearClass = deviceYearClass
+            self.isDevice = isDevice ?? true
+            self.manufacturer = manufacturer ?? "Apple"
+            self.modelName = modelName ?? UIDevice.current.model
+            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osName = osName ?? UIDevice.current.systemName
+            self.osVersion = osVersion ?? UIDevice.current.systemVersion
+            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+        #else
+            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+            self.brand = brand ?? "Apple"
+            self.deviceName = deviceName
+            self.deviceType = deviceType
+            self.deviceYearClass = deviceYearClass
+            self.isDevice = isDevice ?? true
+            self.manufacturer = manufacturer ?? "Apple"
+            self.modelName = modelName
+            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+            self.osName = osName
+            self.osVersion = osVersion
+            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+        #endif
     }
 }
-

--- a/Sources/AccrueIosSDK/AccrueContextData.swift
+++ b/Sources/AccrueIosSDK/AccrueContextData.swift
@@ -1,15 +1,15 @@
 import SwiftUI
-
 #if canImport(UIKit)
-    import UIKit
+import UIKit
 #endif
 
-@available(macOS 10.15, *)
-public class AccrueContextData: ObservableObject, Equatable {
-    @Published public var userData: AccrueUserData
-    @Published public var settingsData: AccrueSettingsData
-    @Published public var actions: AccrueActionsData
 
+@available(macOS 10.15, *)
+public class AccrueContextData: ObservableObject {
+    @Published public var  userData: AccrueUserData
+    @Published public var  settingsData: AccrueSettingsData
+    @Published public var  actions: AccrueActionsData
+    
     public init(
         userData: AccrueUserData = AccrueUserData(),
         settingsData: AccrueSettingsData = AccrueSettingsData(),
@@ -19,19 +19,8 @@ public class AccrueContextData: ObservableObject, Equatable {
         self.settingsData = settingsData
         self.actions = actions
     }
-
-    public static func == (lhs: AccrueContextData, rhs: AccrueContextData) -> Bool {
-        return lhs.userData == rhs.userData && lhs.settingsData == rhs.settingsData
-            && lhs.actions == rhs.actions
-    }
-
-    public func updateUserData(
-        referenceId: String?, email: String?, phoneNumber: String?,
-        additionalData: [String: String]?
-    ) {
-        userData = AccrueUserData(
-            referenceId: referenceId, email: email, phoneNumber: phoneNumber,
-            additionalData: additionalData)
+    public func updateUserData(referenceId: String?, email: String?, phoneNumber: String?, additionalData: [String: String]?) {
+        userData = AccrueUserData(referenceId: referenceId, email: email, phoneNumber: phoneNumber, additionalData: additionalData)
     }
     public func updateSettingsData(shouldInheritAuthentication: Bool) {
         settingsData = AccrueSettingsData(shouldInheritAuthentication: shouldInheritAuthentication)
@@ -39,17 +28,17 @@ public class AccrueContextData: ObservableObject, Equatable {
     public func setAction(action: String) {
         actions = AccrueActionsData(action: action)
     }
-    public func clearAction() {
+    public func clearAction(){
         actions = AccrueActionsData()
     }
-
+    
 }
-public struct AccrueUserData: Equatable {
+public struct AccrueUserData {
     public let referenceId: String?
     public let email: String?
     public let phoneNumber: String?
     public let additionalData: [String: String]?
-
+    
     public init(
         referenceId: String? = nil,
         email: String? = nil,
@@ -63,18 +52,18 @@ public struct AccrueUserData: Equatable {
     }
 }
 
-public struct AccrueActionsData: Equatable {
+public struct AccrueActionsData {
     public let action: String?
-
-    public init(action: String? = nil) {
+    
+    public init( action: String? = nil) {
         self.action = action
     }
 }
 
-public struct AccrueSettingsData: Equatable {
+public struct AccrueSettingsData {
     public let shouldInheritAuthentication: Bool
-
-    public init(shouldInheritAuthentication: Bool = true) {
+    
+    public init( shouldInheritAuthentication: Bool = true) {
         self.shouldInheritAuthentication = shouldInheritAuthentication
     }
 }
@@ -95,42 +84,37 @@ public struct AccrueDeviceContextData {
     public let osVersion: String?
     // iOS only
     public let modelId: String?
-
-    public init(
-        sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil,
-        deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true,
-        manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil,
-        osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil,
-        modelId: String? = nil
-    ) {
-        #if canImport(UIKit)
-            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-            self.brand = brand ?? "Apple"
-            self.deviceName = deviceName ?? UIDevice.current.name
-            self.deviceType = deviceType ?? UIDevice.current.model
-            self.deviceYearClass = deviceYearClass
-            self.isDevice = isDevice ?? true
-            self.manufacturer = manufacturer ?? "Apple"
-            self.modelName = modelName ?? UIDevice.current.model
-            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osName = osName ?? UIDevice.current.systemName
-            self.osVersion = osVersion ?? UIDevice.current.systemVersion
-            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-        #else
-            self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
-            self.brand = brand ?? "Apple"
-            self.deviceName = deviceName
-            self.deviceType = deviceType
-            self.deviceYearClass = deviceYearClass
-            self.isDevice = isDevice ?? true
-            self.manufacturer = manufacturer ?? "Apple"
-            self.modelName = modelName
-            self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
-            self.osName = osName
-            self.osVersion = osVersion
-            self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
-        #endif
+    
+    public init(sdkVersion: String? = nil, brand: String? = nil, deviceName: String? = nil, deviceType: String? = nil, deviceYearClass: Double? = 0, isDevice: Bool? = true, manufacturer: String? = nil, modelName: String? = nil, osBuildId: String? = nil, osInternalBuildId: String? = nil, osName: String? = nil, osVersion: String? = nil, modelId: String? = nil) {
+#if canImport(UIKit)
+        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+        self.brand = brand ?? "Apple"
+        self.deviceName = deviceName ?? UIDevice.current.name
+        self.deviceType = deviceType ?? UIDevice.current.model
+        self.deviceYearClass = deviceYearClass
+        self.isDevice = isDevice ?? true
+        self.manufacturer = manufacturer ?? "Apple"
+        self.modelName = modelName ?? UIDevice.current.model
+        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osName = osName ?? UIDevice.current.systemName
+        self.osVersion = osVersion ?? UIDevice.current.systemVersion
+        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+#else
+        self.sdkVersion = sdkVersion ?? DeviceHelper.getPackageVersion()
+        self.brand = brand ?? "Apple"
+        self.deviceName = deviceName
+        self.deviceType = deviceType
+        self.deviceYearClass = deviceYearClass
+        self.isDevice = isDevice ?? true
+        self.manufacturer = manufacturer ?? "Apple"
+        self.modelName = modelName
+        self.osBuildId = osBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osInternalBuildId = osInternalBuildId ?? DeviceHelper.getInternalOSVersion()
+        self.osName = osName
+        self.osVersion = osVersion
+        self.modelId = modelId ?? DeviceHelper.getModelIdentifier()
+#endif
     }
 }
+

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -10,17 +10,22 @@ public struct AccrueWallet: View {
     public var shouldShowLoader: Bool = true
     @State private var isLoading: Bool = false
 
-    @ObservedObject var contextData: AccrueContextData
-#if os(iOS)
-    private var WebViewComponent: AccrueWebView {
-        let fallbackUrl = URL(string: AppConstants.productionUrl)!
-        let url = buildURL(isSandbox: isSandbox, url: url) ?? fallbackUrl
-        
-        return AccrueWebView(url: url, contextData: contextData, onAction: onAction, isLoading: $isLoading)
-    }
-#endif
- 
-    public init(merchantId: String, redirectionToken: String?,isSandbox: Bool,url: String? = nil, contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil, shouldShowLoader: Bool = true) {
+    @ObservedObject public var contextData: AccrueContextData
+    #if os(iOS)
+        private var WebViewComponent: AccrueWebView {
+            let fallbackUrl = URL(string: AppConstants.productionUrl)!
+            let url = buildURL(isSandbox: isSandbox, url: url) ?? fallbackUrl
+
+            return AccrueWebView(
+                url: url, contextData: contextData, onAction: onAction, isLoading: $isLoading)
+        }
+    #endif
+
+    public init(
+        merchantId: String, redirectionToken: String?, isSandbox: Bool, url: String? = nil,
+        contextData: AccrueContextData = AccrueContextData(), onAction: ((String) -> Void)? = nil,
+        shouldShowLoader: Bool = true
+    ) {
         self.merchantId = merchantId
         self.redirectionToken = redirectionToken
         self.contextData = contextData
@@ -29,31 +34,30 @@ public struct AccrueWallet: View {
         self.onAction = onAction
         self.shouldShowLoader = shouldShowLoader
     }
-    
+
     public var body: some View {
-#if os(iOS)
-    ZStack {
-        WebViewComponent
-        if isLoading && shouldShowLoader {
-            VStack {
-                AccrueLoader()
+        #if os(iOS)
+            ZStack {
+                WebViewComponent
+                if isLoading && shouldShowLoader {
+                    VStack {
+                        AccrueLoader()
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.white.opacity(0.8))
+                    .edgesIgnoringSafeArea(.all)
+                }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.white.opacity(0.8))
-            .edgesIgnoringSafeArea(.all)
-        }
+        #endif
     }
-#endif
-    }
-    
+
     public func handleEvent(event: String) {
         contextData.setAction(action: event)
     }
-       
-    
-    private func buildURL(isSandbox:Bool, url:String?) -> URL? {
+
+    private func buildURL(isSandbox: Bool, url: String?) -> URL? {
         let apiBaseUrl: String
-        
+
         if isSandbox {
             apiBaseUrl = AppConstants.sandboxUrl
         } else if let validUrl = url {
@@ -65,12 +69,13 @@ public struct AccrueWallet: View {
         urlComponents?.queryItems = [
             URLQueryItem(name: "merchantId", value: merchantId)
         ]
-        
+
         if let redirectionToken = redirectionToken {
-            urlComponents?.queryItems?.append(URLQueryItem(name: "redirectionToken", value: redirectionToken))
+            urlComponents?.queryItems?.append(
+                URLQueryItem(name: "redirectionToken", value: redirectionToken))
         }
-        
+
         return urlComponents?.url
     }
-        
+
 }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -47,6 +47,10 @@ public struct AccrueWallet: View {
                     .background(Color.white.opacity(0.8))
                     .edgesIgnoringSafeArea(.all)
                 }
+            }.onChange(of: contextData.userData) { oldValue, newValue in
+                print("AccrueWallet: Context data changed")
+                print("AccrueWallet: Old referenceId: \(oldValue.phoneNumber ?? "nil")")
+                print("AccrueWallet: New referenceId: \(newValue.phoneNumber ?? "nil")")
             }
         #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -55,7 +55,7 @@ public struct AccrueWallet: View {
         contextData.setAction(action: event)
     }
 
-    public func triggerContextDataUpdates() {
+    public func propagateContextDataChanges() {
         #if os(iOS)
             let webView = WebViewComponent
             webView.triggerContextDataRefresh()

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -55,6 +55,13 @@ public struct AccrueWallet: View {
         contextData.setAction(action: event)
     }
 
+    public func updateContextData() {
+        #if os(iOS)
+            let webView = WebViewComponent
+            webView.updateContextData()
+        #endif
+    }
+
     private func buildURL(isSandbox: Bool, url: String?) -> URL? {
         let apiBaseUrl: String
 

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -55,10 +55,10 @@ public struct AccrueWallet: View {
         contextData.setAction(action: event)
     }
 
-    public func updateContextData() {
+    public func triggerContextDataUpdates() {
         #if os(iOS)
             let webView = WebViewComponent
-            webView.updateContextData()
+            webView.triggerContextDataRefresh()
         #endif
     }
 

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -47,10 +47,6 @@ public struct AccrueWallet: View {
                     .background(Color.white.opacity(0.8))
                     .edgesIgnoringSafeArea(.all)
                 }
-            }.onChange(of: contextData.userData) { oldValue, newValue in
-                print("AccrueWallet: Context data changed")
-                print("AccrueWallet: Old referenceId: \(oldValue.phoneNumber ?? "nil")")
-                print("AccrueWallet: New referenceId: \(newValue.phoneNumber ?? "nil")")
             }
         #endif
     }

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -48,7 +48,7 @@ public struct AccrueWallet: View {
                     .edgesIgnoringSafeArea(.all)
                 }
             }
-            .onChange(of: contextData) { _ in
+            .onReceive(contextData.objectWillChange) { _ in
                 propagateContextDataChanges()
             }
         #endif

--- a/Sources/AccrueIosSDK/AccrueWallet.swift
+++ b/Sources/AccrueIosSDK/AccrueWallet.swift
@@ -48,6 +48,9 @@ public struct AccrueWallet: View {
                     .edgesIgnoringSafeArea(.all)
                 }
             }
+            .onChange(of: contextData) { _ in
+                propagateContextDataChanges()
+            }
         #endif
     }
 
@@ -55,7 +58,7 @@ public struct AccrueWallet: View {
         contextData.setAction(action: event)
     }
 
-    public func propagateContextDataChanges() {
+    private func propagateContextDataChanges() {
         #if os(iOS)
             let webView = WebViewComponent
             webView.triggerContextDataRefresh()

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -217,9 +217,17 @@
 
         private func refreshContextData(webView: WKWebView) {
             if let contextData = contextData {
+                print("AccrueWebView: Refreshing context data in WebView")
+                print("AccrueWebView: Current user data -")
+                print("AccrueWebView: ReferenceId: \(contextData.userData.referenceId ?? "nil")")
+                print("AccrueWebView: Email: \(contextData.userData.email ?? "nil")")
+                print("AccrueWebView: PhoneNumber: \(contextData.userData.phoneNumber ?? "nil")")
                 let contextDataScript = generateContextDataScript(contextData: contextData)
-                print("Refreshing contextData: \(contextDataScript)")
+                print("AccrueWebView: Injecting updated context data script")
                 webView.evaluateJavaScript(contextDataScript)
+                print("AccrueWebView: Context data refresh completed")
+            } else {
+                print("AccrueWebView: No context data available to refresh")
             }
         }
 

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -1,330 +1,353 @@
 #if canImport(UIKit)
 
-import SwiftUI
-import WebKit
-import UIKit
-import Foundation
-import SafariServices
+    import SwiftUI
+    import WebKit
+    import UIKit
+    import Foundation
+    import SafariServices
 
+    @available(iOS 13.0, macOS 10.15, *)
+    public struct AccrueWebView: UIViewRepresentable {
+        public let url: URL
+        public var contextData: AccrueContextData?
+        public var onAction: ((String) -> Void)?
+        @Binding var isLoading: Bool
 
-@available(iOS 13.0, macOS 10.15, *)
-public struct AccrueWebView: UIViewRepresentable {
-    public let url: URL
-    public var contextData: AccrueContextData?
-    public var onAction: ((String) -> Void)?
-    @Binding var isLoading: Bool
-    
-    // Add a static dictionary to track WebView instances
-    private static var webViewInstances: [URL: WKWebView] = [:]
+        // Add a static dictionary to track WebView instances
+        private static var webViewInstances: [URL: WKWebView] = [:]
 
-    public init(url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil, isLoading: Binding<Bool>) {
-        self.url = url
-        self.contextData = contextData
-        self.onAction = onAction
-        self._isLoading = isLoading
-    }
-    public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate, WKUIDelegate {
-        var parent: AccrueWebView
-        
-        public init(parent: AccrueWebView) {
-            self.parent = parent
+        public init(
+            url: URL, contextData: AccrueContextData? = nil, onAction: ((String) -> Void)? = nil,
+            isLoading: Binding<Bool>
+        ) {
+            self.url = url
+            self.contextData = contextData
+            self.onAction = onAction
+            self._isLoading = isLoading
         }
-        
-        public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-            if message.name == AccrueWebEvents.EventHandlerName, let userData = message.body as? String {
-                parent.onAction?(userData)
+        public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate,
+            WKUIDelegate
+        {
+            var parent: AccrueWebView
+
+            public init(parent: AccrueWebView) {
+                self.parent = parent
             }
-        }
-        // Intercept navigation actions for internal vs external URLs
-        public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-            // Only handle navigation if it was triggered by a link (not by an iframe load, script, etc.)
-            if navigationAction.navigationType == .linkActivated {
+
+            public func userContentController(
+                _ userContentController: WKUserContentController,
+                didReceive message: WKScriptMessage
+            ) {
+                if message.name == AccrueWebEvents.EventHandlerName,
+                    let userData = message.body as? String
+                {
+                    parent.onAction?(userData)
+                }
+            }
+            // Intercept navigation actions for internal vs external URLs
+            public func webView(
+                _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+            ) {
+                // Only handle navigation if it was triggered by a link (not by an iframe load, script, etc.)
+                if navigationAction.navigationType == .linkActivated {
+                    if let url = navigationAction.request.url {
+                        if isDeepLink(url) {
+                            openSystemDeepLink(url: url)
+                            return
+                        }
+                        // Check if the URL is external (i.e., different from the original host)
+                        if shouldOpenExternally(url: url) {
+                            print("Link clicked, openning In-App Browser")
+                            openInAppBrowser(url: url)
+                            decisionHandler(.cancel)
+                            return
+                        }
+                    }
+                }
+                decisionHandler(.allow)
+            }
+
+            // Handle popups or window.open calls in the web view
+            public func webView(
+                _ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+                for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures
+            ) -> WKWebView? {
                 if let url = navigationAction.request.url {
                     if isDeepLink(url) {
                         openSystemDeepLink(url: url)
-                        return
+                        return nil
                     }
-                    // Check if the URL is external (i.e., different from the original host)
                     if shouldOpenExternally(url: url) {
-                        print("Link clicked, openning In-App Browser")
+                        print("Pop Up triggered, openning In-App Browser")
+                        // Open the link in an in-app browser (SFSafariViewController)
                         openInAppBrowser(url: url)
-                        decisionHandler(.cancel)
-                        return
+                        return nil
                     }
                 }
-            }
-            decisionHandler(.allow)
-        }
-        
-        // Handle popups or window.open calls in the web view
-        public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-            if let url = navigationAction.request.url {
-                if isDeepLink(url) {
-                    openSystemDeepLink(url: url)
-                    return nil
-                }
-                if shouldOpenExternally(url: url) {
-                    print("Pop Up triggered, openning In-App Browser")
-                    // Open the link in an in-app browser (SFSafariViewController)
-                    openInAppBrowser(url: url)
-                    return nil
-                }
-            }
-            return nil
-        }
-
-         
-        public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            DispatchQueue.main.async {
-                self.parent.isLoading = true  // ✅ Safe UI update
-            }
-        }
-        
-        public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            DispatchQueue.main.async {
-                self.parent.isLoading = false
-            }
-        }
-        
-        public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            DispatchQueue.main.async {
-                self.parent.isLoading = false
-            }
-        }
-        
-        // Helper function to determine if the URL should be opened externally
-        private func shouldOpenExternally(url: URL) -> Bool {
-            // Only open external URLs (i.e., URLs not matching the parent WebView's host)
-            if let host = url.host {
-                return host != parent.url.host
+                return nil
             }
 
-            return false
-        }
-        // Open the URL in an in-app browser (SFSafariViewController)
-        private func openInAppBrowser(url: URL) {
-            guard let viewController = UIApplication.shared.windows.first?.rootViewController else { return }
-            let safariVC = SFSafariViewController(url: url)
-            viewController.present(safariVC, animated: true, completion: nil)
-        }
-      
-        private func isDeepLink(_ url: URL) -> Bool {
-            guard let scheme = url.scheme?.lowercased() else {
-               return false
-            }
-            return !["http", "https", "mailto", "tel", "sms", "ftp"].contains(scheme)
-        }
-        
-        private func openSystemDeepLink(url: URL) {
-            if UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url, options: [:]) { success in
-                    if !success {
-                        print("Failed to open deep link: \(url)")
-                    }
+            public func webView(
+                _ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!
+            ) {
+                DispatchQueue.main.async {
+                    self.parent.isLoading = true  // ✅ Safe UI update
                 }
-            } else {
-                print("No app can handle deep link: \(url)")
             }
-        }
-    }
-    public func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
-    }
-    public func makeUIView(context: Context) -> WKWebView {
-        // Check if we already have a WebView instance for this URL
-        if let existingWebView = Self.webViewInstances[url] {
-            return existingWebView
-        }
-        
-        // Create a shared process pool
-        let processPool = WKProcessPool()
-        
-        // Configure the website data store
-        let configuration = WKWebViewConfiguration()
-        configuration.processPool = processPool
-        configuration.websiteDataStore = .default()
-        
-        // Create WebView with the configuration
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        
-        // Set the navigation delegate
-        webView.navigationDelegate = context.coordinator
-        webView.uiDelegate = context.coordinator
-        
-        // Disable zoom and pinch effect
-        webView.isMultipleTouchEnabled = false
-        webView.scrollView.pinchGestureRecognizer?.isEnabled = false
-        webView.scrollView.minimumZoomScale = 1.0
-        webView.scrollView.maximumZoomScale = 1.0
-        
-        if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-        }
-        
-        // Add the script message handler
-        let userContentController = webView.configuration.userContentController
-        userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)
-        
-        // Inject JavaScript to set context data
-        insertContextData(userController: userContentController)
-        
-        // Store the WebView instance
-        Self.webViewInstances[url] = webView
-        
-        return webView
-    }
-    public func updateUIView(_ uiView: WKWebView, context: Context) {
-        // Only load the URL if it's different from the current one
-        if url != uiView.url {
-            var request = URLRequest(url: url)
-            request.cachePolicy = .returnCacheDataElseLoad
-            uiView.load(request)
-        }
-        
-        // Refresh context data
-        refreshContextData(webView: uiView)
-        if let action = contextData?.actions.action {
-            sendEventsToWebView(webView: uiView, action: action)
-        }
-    }
-    
-    private func sendEventsToWebView(webView: WKWebView, action: String?){
-        if(action == "AccrueTabPressed"){
-            sendCustomEventGoToHomeScreen(webView: webView)
-        }else {
-            print("Event not supported: \(action)")
-        }
-    }
-    
-    
-    
-    private func refreshContextData(webView: WKWebView) -> Void {
-        if let contextData = contextData {
-            let contextDataScript = generateContextDataScript(contextData: contextData)
-            print("Refreshing contextData: \(contextDataScript)")
-            webView.evaluateJavaScript(contextDataScript)
-        }
-    }
-    
-    private func insertContextData(userController: WKUserContentController) -> Void {
-        if let contextData = contextData {
-            let contextDataScript = generateContextDataScript(contextData: contextData)
-            print("Inserting contextData: \(contextDataScript)")
-            let userScript = WKUserScript(source: contextDataScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-            userController.addUserScript(userScript)
-        }
-    }
-    // Generate JavaScript for Context Data
-    private func generateContextDataScript(contextData: AccrueContextData) -> String {
-        let userData = contextData.userData
-        let settingsData = contextData.settingsData
-        let deviceContextData = AccrueDeviceContextData()
-        let additionalDataJSON = UserDataHelper.parseDictionaryToJSONString(contextData.userData.additionalData)
-        return """
-          (function() {
-                window["\(AccrueWebEvents.EventHandlerName)"] = {
-                    "contextData": {
-                        "userData": {
-                            "referenceId": \(userData.referenceId.map { "\"\($0)\"" } ?? "null"),
-                            "email": \(userData.email.map { "\"\($0)\"" } ?? "null"),
-                            "phoneNumber": \(userData.phoneNumber.map { "\"\($0)\"" } ?? "null"),
-                            "additionalData": \(additionalDataJSON)
-                        },
-                        "settingsData": {
-                            "shouldInheritAuthentication": \(settingsData.shouldInheritAuthentication)
-                        },
-                        "deviceData": {
-                            "sdk": "\(deviceContextData.sdk)",
-                            "sdkVersion": "\(deviceContextData.sdkVersion ?? "null")",
-                            "brand": "\(deviceContextData.brand ?? "null")",
-                            "deviceName": "\(deviceContextData.deviceName ?? "null")",
-                            "deviceType": "\(deviceContextData.deviceType ?? "")",
-                            "deviceYearClass": "\(deviceContextData.deviceYearClass ?? 0)",
-                            "isDevice": \(deviceContextData.isDevice),
-                            "manufacturer": "\(deviceContextData.manufacturer ?? "null")",
-                            "modelName": "\(deviceContextData.modelName ?? "null")",
-                            "osBuildId": "\(deviceContextData.osBuildId ?? "null")",
-                            "osInternalBuildId": "\(deviceContextData.osInternalBuildId ?? "null")",
-                            "osName": "\(deviceContextData.osName ?? "null")",
-                            "osVersion": "\(deviceContextData.osVersion ?? "null")",
-                            "modelId": "\(deviceContextData.modelId ?? "null")"
+
+            public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+                DispatchQueue.main.async {
+                    self.parent.isLoading = false
+                }
+            }
+
+            public func webView(
+                _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
+            ) {
+                DispatchQueue.main.async {
+                    self.parent.isLoading = false
+                }
+            }
+
+            // Helper function to determine if the URL should be opened externally
+            private func shouldOpenExternally(url: URL) -> Bool {
+                // Only open external URLs (i.e., URLs not matching the parent WebView's host)
+                if let host = url.host {
+                    return host != parent.url.host
+                }
+
+                return false
+            }
+            // Open the URL in an in-app browser (SFSafariViewController)
+            private func openInAppBrowser(url: URL) {
+                guard let viewController = UIApplication.shared.windows.first?.rootViewController
+                else { return }
+                let safariVC = SFSafariViewController(url: url)
+                viewController.present(safariVC, animated: true, completion: nil)
+            }
+
+            private func isDeepLink(_ url: URL) -> Bool {
+                guard let scheme = url.scheme?.lowercased() else {
+                    return false
+                }
+                return !["http", "https", "mailto", "tel", "sms", "ftp"].contains(scheme)
+            }
+
+            private func openSystemDeepLink(url: URL) {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:]) { success in
+                        if !success {
+                            print("Failed to open deep link: \(url)")
                         }
                     }
-                };
-                // Notify the web page that contextData has been updated
-                var event = new CustomEvent("\(AccrueWebEvents.AccrueWalletContextChangedEventKey)", {
-                  detail: window["\(AccrueWebEvents.EventHandlerName)"].contextData
-                });
-                window.dispatchEvent(event);
-          })();
-          """
-    }
-    
-    
-    
-    public func sendCustomEventGoToHomeScreen(webView: WKWebView) {
-        sendCustomEvent(
-            webView: webView,
-            eventName: "__GO_TO_HOME_SCREEN",
-            arguments: ""
-        )
-    }
-    
-    public func sendCustomEvent(
-        webView: WKWebView,
-        eventName: String,
-        arguments: String = ""
-    ) {
-        
-        injectEvent(
-            webView: webView,
-            functionIdentifier: eventName,
-            functionArguments: arguments
-        )
-    }
+                } else {
+                    print("No app can handle deep link: \(url)")
+                }
+            }
+        }
+        public func makeCoordinator() -> Coordinator {
+            Coordinator(parent: self)
+        }
+        public func makeUIView(context: Context) -> WKWebView {
+            // Check if we already have a WebView instance for this URL
+            if let existingWebView = Self.webViewInstances[url] {
+                return existingWebView
+            }
 
-    
-    private func injectEvent(
-        webView: WKWebView,
-        functionIdentifier: String,
-        functionArguments: String
-    ) {
-        
-        let script = """
-        (function() {
-            if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
-                window.\(functionIdentifier)(\(functionArguments));
+            // Create a shared process pool
+            let processPool = WKProcessPool()
+
+            // Configure the website data store
+            let configuration = WKWebViewConfiguration()
+            configuration.processPool = processPool
+            configuration.websiteDataStore = .default()
+
+            // Create WebView with the configuration
+            let webView = WKWebView(frame: .zero, configuration: configuration)
+
+            // Set the navigation delegate
+            webView.navigationDelegate = context.coordinator
+            webView.uiDelegate = context.coordinator
+
+            // Disable zoom and pinch effect
+            webView.isMultipleTouchEnabled = false
+            webView.scrollView.pinchGestureRecognizer?.isEnabled = false
+            webView.scrollView.minimumZoomScale = 1.0
+            webView.scrollView.maximumZoomScale = 1.0
+
+            if #available(iOS 16.4, *) {
+                webView.isInspectable = true
             }
-            return "Script injected successfully";
-        })();
-        """
-        webView.evaluateJavaScript(script){ result, error in
-            if let error = error {
-                print("JavaScript injection error: \(error.localizedDescription)")
+
+            // Add the script message handler
+            let userContentController = webView.configuration.userContentController
+            userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)
+
+            // Inject JavaScript to set context data
+            insertContextData(userController: userContentController)
+
+            // Store the WebView instance
+            Self.webViewInstances[url] = webView
+
+            return webView
+        }
+        public func updateUIView(_ uiView: WKWebView, context: Context) {
+            // Only load the URL if it's different from the current one
+            if url != uiView.url {
+                var request = URLRequest(url: url)
+                request.cachePolicy = .returnCacheDataElseLoad
+                uiView.load(request)
+            }
+
+            // Refresh context data
+            refreshContextData(webView: uiView)
+            if let action = contextData?.actions.action {
+                sendEventsToWebView(webView: uiView, action: action)
+            }
+        }
+
+        private func sendEventsToWebView(webView: WKWebView, action: String?) {
+            if action == "AccrueTabPressed" {
+                sendCustomEventGoToHomeScreen(webView: webView)
             } else {
-                print("JavaScript executed successfully: \(String(describing: result))")
-                
+                print("Event not supported: \(action)")
             }
-            contextData?.clearAction()
         }
-        
-    }
-    
-    public static func clearWebsiteData() {
-        let dataTypes = Set([WKWebsiteDataTypeLocalStorage])
-        let date = Date(timeIntervalSince1970: 0)
-        WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: date) {
-            print("Website data cleared")
+
+        private func refreshContextData(webView: WKWebView) {
+            if let contextData = contextData {
+                let contextDataScript = generateContextDataScript(contextData: contextData)
+                print("Refreshing contextData: \(contextDataScript)")
+                webView.evaluateJavaScript(contextDataScript)
+            }
+        }
+
+        private func insertContextData(userController: WKUserContentController) {
+            if let contextData = contextData {
+                let contextDataScript = generateContextDataScript(contextData: contextData)
+                print("Inserting contextData: \(contextDataScript)")
+                let userScript = WKUserScript(
+                    source: contextDataScript, injectionTime: .atDocumentStart,
+                    forMainFrameOnly: false)
+                userController.addUserScript(userScript)
+            }
+        }
+        // Generate JavaScript for Context Data
+        private func generateContextDataScript(contextData: AccrueContextData) -> String {
+            let userData = contextData.userData
+            let settingsData = contextData.settingsData
+            let deviceContextData = AccrueDeviceContextData()
+            let additionalDataJSON = UserDataHelper.parseDictionaryToJSONString(
+                contextData.userData.additionalData)
+            return """
+                (function() {
+                      window["\(AccrueWebEvents.EventHandlerName)"] = {
+                          "contextData": {
+                              "userData": {
+                                  "referenceId": \(userData.referenceId.map { "\"\($0)\"" } ?? "null"),
+                                  "email": \(userData.email.map { "\"\($0)\"" } ?? "null"),
+                                  "phoneNumber": \(userData.phoneNumber.map { "\"\($0)\"" } ?? "null"),
+                                  "additionalData": \(additionalDataJSON)
+                              },
+                              "settingsData": {
+                                  "shouldInheritAuthentication": \(settingsData.shouldInheritAuthentication)
+                              },
+                              "deviceData": {
+                                  "sdk": "\(deviceContextData.sdk)",
+                                  "sdkVersion": "\(deviceContextData.sdkVersion ?? "null")",
+                                  "brand": "\(deviceContextData.brand ?? "null")",
+                                  "deviceName": "\(deviceContextData.deviceName ?? "null")",
+                                  "deviceType": "\(deviceContextData.deviceType ?? "")",
+                                  "deviceYearClass": "\(deviceContextData.deviceYearClass ?? 0)",
+                                  "isDevice": \(deviceContextData.isDevice),
+                                  "manufacturer": "\(deviceContextData.manufacturer ?? "null")",
+                                  "modelName": "\(deviceContextData.modelName ?? "null")",
+                                  "osBuildId": "\(deviceContextData.osBuildId ?? "null")",
+                                  "osInternalBuildId": "\(deviceContextData.osInternalBuildId ?? "null")",
+                                  "osName": "\(deviceContextData.osName ?? "null")",
+                                  "osVersion": "\(deviceContextData.osVersion ?? "null")",
+                                  "modelId": "\(deviceContextData.modelId ?? "null")"
+                              }
+                          }
+                      };
+                      // Notify the web page that contextData has been updated
+                      var event = new CustomEvent("\(AccrueWebEvents.AccrueWalletContextChangedEventKey)", {
+                        detail: window["\(AccrueWebEvents.EventHandlerName)"].contextData
+                      });
+                      window.dispatchEvent(event);
+                })();
+                """
+        }
+
+        public func sendCustomEventGoToHomeScreen(webView: WKWebView) {
+            sendCustomEvent(
+                webView: webView,
+                eventName: "__GO_TO_HOME_SCREEN",
+                arguments: ""
+            )
+        }
+
+        public func sendCustomEvent(
+            webView: WKWebView,
+            eventName: String,
+            arguments: String = ""
+        ) {
+
+            injectEvent(
+                webView: webView,
+                functionIdentifier: eventName,
+                functionArguments: arguments
+            )
+        }
+
+        private func injectEvent(
+            webView: WKWebView,
+            functionIdentifier: String,
+            functionArguments: String
+        ) {
+
+            let script = """
+                (function() {
+                    if (typeof window !== "undefined" && typeof window.\(functionIdentifier) === "function") {
+                        window.\(functionIdentifier)(\(functionArguments));
+                    }
+                    return "Script injected successfully";
+                })();
+                """
+            webView.evaluateJavaScript(script) { result, error in
+                if let error = error {
+                    print("JavaScript injection error: \(error.localizedDescription)")
+                } else {
+                    print("JavaScript executed successfully: \(String(describing: result))")
+
+                }
+                contextData?.clearAction()
+            }
+
+        }
+
+        public static func clearWebsiteData() {
+            let dataTypes = Set([WKWebsiteDataTypeLocalStorage])
+            let date = Date(timeIntervalSince1970: 0)
+            WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: date) {
+                print("Website data cleared")
+            }
+        }
+
+        // Add cleanup method
+        public static func cleanup() {
+            // Remove all WebView instances
+            webViewInstances.removeAll()
+
+            // Clear website data
+            clearWebsiteData()
+        }
+        public func updateContextData(_ newContextData: AccrueContextData) {
+            self.contextData = newContextData
+            if let webView = Self.webViewInstances[url] {
+                refreshContextData(webView: webView)
+            }
         }
     }
-    
-    // Add cleanup method
-    public static func cleanup() {
-        // Remove all WebView instances
-        webViewInstances.removeAll()
-        
-        // Clear website data
-        clearWebsiteData()
-    }
-}
 #endif

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -215,19 +215,11 @@
             }
         }
 
-        public func refreshContextData(webView: WKWebView) {
+        private func refreshContextData(webView: WKWebView) {
             if let contextData = contextData {
-                print("AccrueWebView: Refreshing context data in WebView")
-                print("AccrueWebView: Current user data -")
-                print("AccrueWebView: ReferenceId: \(contextData.userData.referenceId ?? "nil")")
-                print("AccrueWebView: Email: \(contextData.userData.email ?? "nil")")
-                print("AccrueWebView: PhoneNumber: \(contextData.userData.phoneNumber ?? "nil")")
                 let contextDataScript = generateContextDataScript(contextData: contextData)
-                print("AccrueWebView: Injecting updated context data script")
+                print("Refreshing contextData: \(contextDataScript)")
                 webView.evaluateJavaScript(contextDataScript)
-                print("AccrueWebView: Context data refresh completed")
-            } else {
-                print("AccrueWebView: No context data available to refresh")
             }
         }
 
@@ -351,6 +343,13 @@
             // Clear website data
             clearWebsiteData()
         }
-
+        public func updateContextData() {
+            let instance = Self.webViewInstances[url]
+            if let webView = instance {
+                refreshContextData(webView: webView)
+            } else {
+                print("AccrueWebView: No web view found")
+            }
+        }
     }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -155,12 +155,8 @@
                 return existingWebView
             }
 
-            // Create a shared process pool
-            let processPool = WKProcessPool()
-
             // Configure the website data store
             let configuration = WKWebViewConfiguration()
-            configuration.processPool = processPool
             configuration.websiteDataStore = .default()
 
             // Create WebView with the configuration
@@ -343,7 +339,8 @@
             // Clear website data
             clearWebsiteData()
         }
-        public func updateContextData() {
+        // Trigger a context data refresh
+        public func triggerContextDataRefresh() {
             let instance = Self.webViewInstances[url]
             if let webView = instance {
                 refreshContextData(webView: webView)

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -145,12 +145,6 @@ public struct AccrueWebView: UIViewRepresentable {
         let userContentController = webView.configuration.userContentController
         userContentController.add(context.coordinator, name: AccrueWebEvents.EventHandlerName)
         
-         // Observe when app enters foreground
-        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) { _ in
-            print("App entered foreground, reloading WebView")
-            webView.reload()
-        }
-        
         // Inject JavaScript to set context data
         insertContextData(userController: userContentController)
         

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -215,7 +215,7 @@
             }
         }
 
-        private func refreshContextData(webView: WKWebView) {
+        public func refreshContextData(webView: WKWebView) {
             if let contextData = contextData {
                 print("AccrueWebView: Refreshing context data in WebView")
                 print("AccrueWebView: Current user data -")

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -343,11 +343,6 @@
             // Clear website data
             clearWebsiteData()
         }
-        public mutating func updateContextData(_ newContextData: AccrueContextData) {
-            self.contextData = newContextData
-            if let webView = Self.webViewInstances[url] {
-                refreshContextData(webView: webView)
-            }
-        }
+
     }
 #endif

--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -343,7 +343,7 @@
             // Clear website data
             clearWebsiteData()
         }
-        public func updateContextData(_ newContextData: AccrueContextData) {
+        public mutating func updateContextData(_ newContextData: AccrueContextData) {
             self.contextData = newContextData
             if let webView = Self.webViewInstances[url] {
                 refreshContextData(webView: webView)


### PR DESCRIPTION
## Context

Users were being signed out when navigating through the app. After investigation, we found that multiple WebView instances were being created because the `AccrueWallet` component was recreated every time the parent component re-rendered.

To fix this, SDK consumers now need to store the `AccrueWallet` instance in a `@State` variable (or similar) so it's only created once and not recreated on every render.

We also had to update the SDK to allow context data to be updated without recreating the WebView.

## Core Changes in This PR

- **Remove WebView reload on background/foreground transitions**  
  This behavior was previously added as a workaround for session issues, but is no longer necessary after this fix.

- **Call `propagateContextDataChanges` method in the SDK internally**  
  That will call the webView to propagate the `contextDataChange`

- **Leverage `@ObservedObject` for `contextData`**  
  Enables data binding with external context sources, while the exposed `propagateContextDataChanges` ensures updates are pushed to the WebView.

- **Set a default storage policy**  
  Prevents potential issues caused by `undefined` `localStorage`.

- **Ensure singleton WebView instantiation**  
  Guarantees that the WebView is instantiated only once during the component lifecycle.