### PR TITLE
fix: Added webViewWebContentProcessDidTerminate to handle webview process being killed while being iddle and in the background

### DIFF
--- a/Sources/AccrueIosSDK/AccrueWebView.swift
+++ b/Sources/AccrueIosSDK/AccrueWebView.swift
@@ -133,6 +133,23 @@
                 }
             }
 
+            // MARK: - Content process termination
+            public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+                print("❌ WebView content process terminated")
+                hardReload(webView)
+            }
+
+            private func hardReload(_ webView: WKWebView) {
+                DispatchQueue.main.async {
+                    self.parent.isLoading = true
+                    if let current = webView.url {
+                        webView.load(URLRequest(url: current))
+                    } else {
+                        webView.load(URLRequest(url: self.parent.url))
+                    }
+                }
+            }
+
             // Helper function to determine if the URL should be opened externally
             private func shouldOpenExternally(url: URL) -> Bool {
                 // Only open external URLs (i.e., URLs not matching the parent WebView's host)


### PR DESCRIPTION
# Description
For WSM we had the same issue where some users where reporting a blank screen after leaving the app in the background, adding `webViewWebContentProcessDidTerminate` delegate, this is hard to reproduce on a simulator, I tested the function to make sure it does reload the webview properly but I was not able to fire the event on the simulator.

<img width="587" height="105" alt="image" src="https://github.com/user-attachments/assets/d1d20253-1bdc-4033-9aa4-f254583eaa6d" />


# Ticket
[SNIPES-895](https://accruemoney.atlassian.net/browse/SNIPES-895)